### PR TITLE
chore/revise typo datastring to stringdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ metadata:
   name: update-ksops-secrets
 pipeline:
   mutators:
-    - image: ghcr.io/neutronth/kpt-update-ksops-secrets:0.3
+    - image: ghcr.io/neutronth/kpt-update-ksops-secrets:0.4
       configPath: update-ksops-secrets.yaml
 ```
 
@@ -173,7 +173,7 @@ Alternatively, invoke function directly without the `Kptfile`
 
 ```shell
 $ kpt fn eval \
-    --image=ghcr.io/neutronth/kpt-update-ksops-secrets:0.3 \
+    --image=ghcr.io/neutronth/kpt-update-ksops-secrets:0.4 \
     --fn-config=update-ksops-secrets.yaml
 ```
 
@@ -256,7 +256,7 @@ Hence, if the encrypted files recipients include the PGP/GPG fingerprints, the `
 
 ```shell
 $ kpt fn eval \
-    --image=ghcr.io/neutronth/kpt-update-ksops-secrets:0.3 \
+    --image=ghcr.io/neutronth/kpt-update-ksops-secrets:0.4 \
     --fn-config=update-ksops-secrets.yaml \
     --network
 ```

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: unencrypted-secrets
-dataString:
+stringData:
   test2: test2
   UPPER_CASE: upper_case
 data:

--- a/example/unencrypted-secrets.yaml
+++ b/example/unencrypted-secrets.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: unencrypted-secrets
-dataString:
+stringData:
   test2: test2
   UPPER_CASE: upper_case
 data:

--- a/generated/docs.go
+++ b/generated/docs.go
@@ -100,7 +100,7 @@ Let's start with the input resource in a package, see the [Note](#create-unencry
   kind: Secret
   metadata:
     name: unencrypted-secrets
-  dataString:
+  stringData:
     test2: test2
     UPPER_CASE: upper_case
   data:
@@ -142,7 +142,7 @@ Declare the new desired values for setters in the functionConfig file.
     name: update-ksops-secrets
   pipeline:
     mutators:
-      - image: ghcr.io/neutronth/kpt-update-ksops-secrets:0.3
+      - image: ghcr.io/neutronth/kpt-update-ksops-secrets:0.4
         configPath: update-ksops-secrets.yaml
 
 Invoke the function:
@@ -152,7 +152,7 @@ Invoke the function:
 Alternatively, invoke function directly without the ` + "`" + `Kptfile` + "`" + `
 
   $ kpt fn eval \
-      --image=ghcr.io/neutronth/kpt-update-ksops-secrets:0.3 \
+      --image=ghcr.io/neutronth/kpt-update-ksops-secrets:0.4 \
       --fn-config=update-ksops-secrets.yaml
 
 If you encountered the error with the PGP/GPG recipients encryption, see the [Note](#gpg-receive-keys-requires-network-to-work-properly) to understand the limitation and working solution.

--- a/generator/secretref.go
+++ b/generator/secretref.go
@@ -70,7 +70,7 @@ func (sr *secretReference) Get(key string) (value string, b64encoded bool, err e
 }
 
 func (sr *secretReference) GetExact(name, key string) (value string, b64encoded bool, err error) {
-	if field := sr.lookup(name, key, "dataString"); field != nil {
+	if field := sr.lookup(name, key, "stringData"); field != nil {
 		value = yaml.GetValue(field.Value)
 		b64encoded = false
 	} else if field := sr.lookup(name, key, "data"); field != nil {

--- a/generator/secretref_test.go
+++ b/generator/secretref_test.go
@@ -47,7 +47,7 @@ kind: Secret
 metadata:
   name: unencrypted-secrets
 type: Opaque
-dataString:
+stringData:
   test2: test2
   UPPER_CASE: upper_case
 data:


### PR DESCRIPTION
- chore: s/dataString/stringData/ in README.md and example
- chore: bump the function image version to 0.4 in README.md
- chore: generate the generated/docs.go
