### PR TITLE
fix: avoid double encryption on same secret and secret-ref name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,7 @@ jobs:
           version: v0.6.14
 
       - name: run integration test
+        run: earthly --ci --verbose +integration-test
+
+      - name: run integration image test
         run: earthly --ci --verbose --allow-privileged +integration-image-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: earthly/actions/setup-earthly@v1
         with:
-          version: v0.6.14
+          version: v0.6.23
 
       - name: run integration test
         run: earthly --ci --verbose +integration-test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: earthly/actions/setup-earthly@v1
         with:
-          version: v0.6.14
+          version: v0.6.23
 
       - name: run integration test
         run: earthly --ci --verbose --allow-privileged +integration-image-test

--- a/Earthfile
+++ b/Earthfile
@@ -133,6 +133,7 @@ integration-base:
   COPY example/update-ksops-secrets.yaml ./
   COPY example/unencrypted-secrets.yaml ./
   COPY example/unencrypted-secrets-config-txt.yaml ./
+  COPY example/test-update-ksops-secrets.yaml ./
   COPY example/gpg-publickeys.yaml ./
   COPY example/age.key.txt ${SOPS_AGE_KEYS_DIR}/keys.txt
   COPY scripts/integration-test /usr/local/bin/integration-test

--- a/example/test-update-ksops-secrets.yaml
+++ b/example/test-update-ksops-secrets.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-update-ksops-secrets
+data:
+  same-secret-and-secret-ref-name: dGVzdA==

--- a/example/update-ksops-secrets.yaml
+++ b/example/update-ksops-secrets.yaml
@@ -7,11 +7,13 @@ secret:
   references:
   - unencrypted-secrets
   - unencrypted-secrets-config-txt
+  - test-update-ksops-secrets
   items:
   - test
   - test2
   - UPPER_CASE
   - config.txt
+  - same-secret-and-secret-ref-name
 recipients:
 - type: age
   recipient: age1x7pzjx4r05ar95pulf20knx0mkscaxa0zhtqr948wza3863fvees8tzaaa

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -36,6 +36,7 @@ apiVersion: v1
 data:
   UPPER_CASE: dXBwZXJfY2FzZQ==
   config.txt: Y29uZmlnLnR4dAo=
+  same-secret-and-secret-ref-name: dGVzdA==
   test: dGVzdA==
   test2: dGVzdDI=
 kind: Secret
@@ -73,4 +74,5 @@ run "partial generation"
 
 # Drop all remaining unencrypted secret
 rm -f unencrypted-secrets.yaml
+rm -f test-update-ksops-secrets.yaml
 run "no updated generation"


### PR DESCRIPTION
* Double encryption could occured when the user specify the
  `secret/references` name as same as the `secret` name

  ```
  apiVersion: fn.kpt.dev/v1alpha1
  kind: UpdateKSopsSecrets
  metadata:
    name: config-token-secret
  secret:
    type: Opaque
    references:
      - config-token-secret
    items:
      - config_token.json
  ```
  When the unencrypted `config-token-secret` is missing,
  the Kpt will pass an encrypted one to the pipeline and
  caused a double encryption instead of skipping.

  Closes #20
