### PR TITLE
Support mutli-arch images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,13 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+
       - uses: actions/checkout@v2
         with:
           submodules: recursive

--- a/Earthfile
+++ b/Earthfile
@@ -112,6 +112,9 @@ image:
 
   SAVE IMAGE --push ghcr.io/neutronth/kpt-update-ksops-secrets:${IMAGE_TAG}
 
+image-all-platforms:
+  BUILD --platform=linux/amd64 --platform=linux/arm64 +image
+
 integration-base:
   ARG BASE_IMAGE
   FROM ${BASE_IMAGE}


### PR DESCRIPTION
Introduce new earthly tasks to build multi-arch images. Currently, support only `linux/amd64` and `linux/arm64`.

Fixes #25