### PR TITLE
feat ci/publish image all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: earthly/actions/setup-earthly@v1
         with:
-          version: v0.6.23
+          version: v0.7.6
 
       - name: run integration test
         run: earthly --ci --verbose +integration-test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: earthly/actions/setup-earthly@v1
         with:
-          version: v0.6.23
+          version: v0.7.6
 
       - name: run integration test
         run: earthly --ci --verbose --allow-privileged +integration-image-test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,5 +39,5 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: build and publish image
-        run: earthly --ci --verbose --push +image --IMAGE_TAG=${{ steps.vars.outputs.tag }}
+      - name: build and publish image linux/amd64 and linux/arm64 platforms
+        run: earthly --ci --verbose --push +image-all-platforms --IMAGE_TAG=${{ steps.vars.outputs.tag }}

--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,6 @@
-VERSION 0.6
+VERSION 0.7
+
+ARG --global IMAGE_TAG="dev"
 
 source:
   FROM golang:1.20-bullseye
@@ -85,7 +87,7 @@ download-tools:
   SAVE ARTIFACT ksops
 
 image:
-  ARG IMAGE_TAG="dev"
+  ARG IMAGE_TAG="${IMAGE_TAG}"
 
   FROM debian:bullseye-slim
 

--- a/Earthfile
+++ b/Earthfile
@@ -40,7 +40,7 @@ lint:
   FROM +source
 
   RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.0
-  RUN golangci-lint run --verbose ./...
+  RUN golangci-lint run --verbose --timeout="5m" ./...
 
 test:
   FROM +lint


### PR DESCRIPTION
- chore(ci): golangci-lint timed-out in linux/arm64 platform
- feat(ci): bump Earthly to v0.7.6
- chore(ci): publish image for linux/amd64 and linux/arm64 platform
