### PR TITLE
Run Earthly in Dagger with Earthly SDK

### DIFF
--- a/.github/workflows/ci-v2.yaml
+++ b/.github/workflows/ci-v2.yaml
@@ -9,7 +9,7 @@ on:
       - "*"
 
 jobs:
-  ci:
+  integration-test:
     name: Integration Test
     runs-on: ubuntu-latest
     steps:
@@ -20,6 +20,15 @@ jobs:
       - uses: dagger/dagger-for-github@8.0.0
         with:
           call: integration-test
+
+  
+  integration-image-test:
+    name: Integration Image Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - uses: dagger/dagger-for-github@8.0.0
         with:

--- a/.github/workflows/ci-v2.yaml
+++ b/.github/workflows/ci-v2.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: dagger/dagger-for-github@8.0.0
         with:
-          call: integration-test
+          call: --docker-unix-sock=unix:///var/run/docker.sock integration-test
 
   
   integration-image-test:
@@ -34,4 +34,4 @@ jobs:
 
       - uses: dagger/dagger-for-github@8.0.0
         with:
-          call: integration-image-test
+          call: --docker-unix-sock=unix:///var/run/docker.sock integration-image-test

--- a/.github/workflows/ci-v2.yaml
+++ b/.github/workflows/ci-v2.yaml
@@ -17,6 +17,8 @@ jobs:
         with:
           submodules: recursive
 
+      - run: df -h
+
       - uses: dagger/dagger-for-github@8.0.0
         with:
           call: integration-test

--- a/.github/workflows/ci-v2.yaml
+++ b/.github/workflows/ci-v2.yaml
@@ -1,0 +1,26 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  ci:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - uses: dagger/dagger-for-github@8.0.0
+        with:
+          call: integration-test
+
+      - uses: dagger/dagger-for-github@8.0.0
+        with:
+          call: integration-image-test

--- a/.github/workflows/ci-v2.yaml
+++ b/.github/workflows/ci-v2.yaml
@@ -17,8 +17,6 @@ jobs:
         with:
           submodules: recursive
 
-      - run: df -h
-
       - uses: dagger/dagger-for-github@8.0.0
         with:
           call: --docker-unix-sock=unix:///var/run/docker.sock integration-test

--- a/Earthfile
+++ b/Earthfile
@@ -71,8 +71,14 @@ download-tools:
   ARG KUSTOMIZE_VERSION="5.4.2"
   ARG KUSTOMIZE_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz"
 
+  IF [ $TARGETARCH = "amd64" ]
+    ARG KSOPS_ARCH="x86_64"
+  ELSE
+    ARG KSOPS_ARCH=$TARGETARCH
+  END
+
   ARG KSOPS_VERSION="4.3.1"
-  ARG KSOPS_URL="https://github.com/viaduct-ai/kustomize-sops/releases/download/v${KSOPS_VERSION}/ksops_${KSOPS_VERSION}_Linux_${TARGETARCH}.tar.gz"
+  ARG KSOPS_URL="https://github.com/viaduct-ai/kustomize-sops/releases/download/v${KSOPS_VERSION}/ksops_${KSOPS_VERSION}_Linux_${KSOPS_ARCH}.tar.gz"
 
   RUN apt update --yes \
     && apt install --yes curl

--- a/Earthfile
+++ b/Earthfile
@@ -63,14 +63,16 @@ download-tools:
   FROM debian:bullseye-slim
   ENV DEBIAN_FRONTEND=noninteractive
 
+  ARG TARGETARCH
+
   ARG KPT_VERSION="1.0.0-beta.52"
-  ARG KPT_URL="https://github.com/GoogleContainerTools/kpt/releases/download/v${KPT_VERSION}/kpt_linux_amd64"
+  ARG KPT_URL="https://github.com/GoogleContainerTools/kpt/releases/download/v${KPT_VERSION}/kpt_linux_${TARGETARCH}"
 
   ARG KUSTOMIZE_VERSION="5.4.2"
-  ARG KUSTOMIZE_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+  ARG KUSTOMIZE_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz"
 
   ARG KSOPS_VERSION="4.3.1"
-  ARG KSOPS_URL="https://github.com/viaduct-ai/kustomize-sops/releases/download/v${KSOPS_VERSION}/ksops_${KSOPS_VERSION}_Linux_x86_64.tar.gz"
+  ARG KSOPS_URL="https://github.com/viaduct-ai/kustomize-sops/releases/download/v${KSOPS_VERSION}/ksops_${KSOPS_VERSION}_Linux_${TARGETARCH}.tar.gz"
 
   RUN apt update --yes \
     && apt install --yes curl

--- a/Earthfile
+++ b/Earthfile
@@ -33,7 +33,7 @@ build-sops:
     && cd sops \
     && git checkout v3.9.0 \
     && sed -i'' 's/e.SetIndent(4)/e.SetIndent(2)/g' stores/yaml/store.go \
-    && go mod download -x \
+    && go mod download \
     && go build -o /sops ./cmd/sops
 
   SAVE ARTIFACT /sops

--- a/Earthfile
+++ b/Earthfile
@@ -9,7 +9,7 @@ source:
   WORKDIR /src
 
   COPY go.mod go.sum ./
-  RUN go mod download -x
+  RUN go mod download
 
   COPY . .
 

--- a/dagger.json
+++ b/dagger.json
@@ -1,0 +1,7 @@
+{
+  "name": "kpt-update-ksops-secrets",
+  "engineVersion": "v0.18.6",
+  "sdk": {
+    "source": "github.com/wingyplus/dagger-earthly-sdk"
+  }
+}


### PR DESCRIPTION
This PR is a first step to migrates the Earthly pipeline to Dagger with [Earthly SDK](https://github.com/wingyplus/dagger-earthly-sdk). 

The SDK will convert all Earthly targets to Dagger function (arguments is convert to function arguments as well). So if you run `dagger functions`, it will show:

```
$ dagger functions
✔ connect 0.4s
✔ load module 6.3s

Name                     Description
build                    -
build-sops               -
download-tools           -
image                    -
image-all-platforms      -
integration-base         -
integration-image-test   -
integration-test         -
lint                     -
source                   -
test                     -
```

And those functions can be called with `dagger call <fn-name>` (example, `dagger call lint`) as well. 

NOTE: the SAVE IMAGE and SAVE ARTIFACT are not work as expected. but it'll work soon. :D