### PR TITLE
chore: bump kpt-update-ksops-secrets image to 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ metadata:
   name: update-ksops-secrets
 pipeline:
   mutators:
-    - image: ghcr.io/neutronth/kpt-update-ksops-secrets:0.13
+    - image: ghcr.io/neutronth/kpt-update-ksops-secrets:0.14
       configPath: update-ksops-secrets.yaml
 ```
 
@@ -173,7 +173,7 @@ Alternatively, invoke function directly without the `Kptfile`
 
 ```shell
 $ kpt fn eval \
-    --image=ghcr.io/neutronth/kpt-update-ksops-secrets:0.13 \
+    --image=ghcr.io/neutronth/kpt-update-ksops-secrets:0.14 \
     --fn-config=update-ksops-secrets.yaml
 ```
 
@@ -257,7 +257,7 @@ Hence, if the encrypted files recipients include the PGP/GPG fingerprints, the `
 
 ```shell
 $ kpt fn eval \
-    --image=ghcr.io/neutronth/kpt-update-ksops-secrets:0.13 \
+    --image=ghcr.io/neutronth/kpt-update-ksops-secrets:0.14 \
     --fn-config=update-ksops-secrets.yaml \
     --network
 ```


### PR DESCRIPTION
- Update all references to the kpt-update-ksops-secrets Docker image
  from version 0.13 to 0.14 in the README documentation examples.
